### PR TITLE
Add `TextureViewInfo` type for `TextureView`

### DIFF
--- a/examples/draw/draw_capture_hi_res.rs
+++ b/examples/draw/draw_capture_hi_res.rs
@@ -62,7 +62,7 @@ fn model(app: &App) -> Model {
     let texture_capturer = wgpu::TextureCapturer::default();
 
     // Create the texture reshaper.
-    let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let texture_view = texture.view().build();
     let texture_component_type = texture.component_type();
     let dst_format = Frame::TEXTURE_FORMAT;
     let texture_reshaper = wgpu::TextureReshaper::new(
@@ -156,9 +156,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
         .capture(device, &mut encoder, &model.texture);
 
     // Submit the commands for our drawing and texture capture to the GPU.
-    window
-        .swap_chain_queue()
-        .submit(std::iter::once(encoder.finish()));
+    window.swap_chain_queue().submit(Some(encoder.finish()));
 
     // Submit a function for writing our snapshot to a PNG.
     //

--- a/examples/isf/isf_demo.rs
+++ b/examples/isf/isf_demo.rs
@@ -44,9 +44,7 @@ fn model(app: &App) -> Model {
         sample_count,
         &images_dir,
     );
-    window
-        .swap_chain_queue()
-        .submit(std::iter::once(encoder.finish()));
+    window.swap_chain_queue().submit(Some(encoder.finish()));
 
     let isf_time = Default::default();
 
@@ -71,9 +69,7 @@ fn update(app: &App, model: &mut Model, update: Update) {
     model
         .isf_pipeline
         .encode_update(device, &mut encoder, &images_dir, touched_shaders);
-    window
-        .swap_chain_queue()
-        .submit(std::iter::once(encoder.finish()));
+    window.swap_chain_queue().submit(Some(encoder.finish()));
     model.isf_time.time = update.since_start.secs() as _;
     model.isf_time.time_delta = update.since_last.secs() as _;
 }

--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -62,7 +62,7 @@ fn model(app: &App) -> Model {
     let uniforms_bytes = uniforms_as_bytes(&uniforms);
     let usage = wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::COPY_DST;
     let uniform_buffer = device.create_buffer_init(&BufferInitDescriptor {
-        label: None,
+        label: Some("uniform-buffer"),
         contents: uniforms_bytes,
         usage,
     });
@@ -108,7 +108,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
 
     // The buffer into which we'll read some data.
     let read_buffer = device.create_buffer(&wgpu::BufferDescriptor {
-        label: Some("read_oscillators"),
+        label: Some("read-oscillators"),
         size: compute.oscillator_buffer_size,
         usage: wgpu::BufferUsage::MAP_READ
             | wgpu::BufferUsage::COPY_DST
@@ -122,14 +122,14 @@ fn update(app: &App, model: &mut Model, _update: Update) {
     let uniforms_bytes = uniforms_as_bytes(&uniforms);
     let usage = wgpu::BufferUsage::COPY_SRC;
     let new_uniform_buffer = device.create_buffer_init(&BufferInitDescriptor {
-        label: None,
+        label: Some("uniform-data-transfer"),
         contents: uniforms_bytes,
         usage,
     });
 
     // The encoder we'll use to encode the compute pass.
     let desc = wgpu::CommandEncoderDescriptor {
-        label: Some("oscillator_compute"),
+        label: Some("oscillator-compute"),
     };
     let mut encoder = device.create_command_encoder(&desc);
     encoder.copy_buffer_to_buffer(
@@ -154,9 +154,7 @@ fn update(app: &App, model: &mut Model, _update: Update) {
     );
 
     // Submit the compute pass to the device's queue.
-    window
-        .swap_chain_queue()
-        .submit(std::iter::once(encoder.finish()));
+    window.swap_chain_queue().submit(Some(encoder.finish()));
 
     // Spawn a future that reads the result of the compute pass.
     let oscillators = model.oscillators.clone();

--- a/examples/wgpu/wgpu_image/wgpu_image.rs
+++ b/examples/wgpu/wgpu_image/wgpu_image.rs
@@ -62,8 +62,7 @@ fn model(app: &App) -> Model {
     // Create the sampler for sampling from the source texture.
     let sampler = wgpu::SamplerBuilder::new().build(device);
 
-    let bind_group_layout =
-        create_bind_group_layout(device, texture_view.component_type().unwrap());
+    let bind_group_layout = create_bind_group_layout(device, texture_view.component_type());
     let bind_group = create_bind_group(device, &bind_group_layout, &texture_view, &sampler);
     let pipeline_layout = create_pipeline_layout(device, &bind_group_layout);
     let render_pipeline = create_render_pipeline(

--- a/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
+++ b/examples/wgpu/wgpu_image_sequence/wgpu_image_sequence.rs
@@ -95,8 +95,7 @@ fn model(app: &App) -> Model {
     // Create the sampler for sampling from the source texture.
     let sampler = wgpu::SamplerBuilder::new().build(device);
 
-    let bind_group_layout =
-        create_bind_group_layout(device, texture_view.component_type().unwrap());
+    let bind_group_layout = create_bind_group_layout(device, texture_view.component_type());
     let bind_group = create_bind_group(device, &bind_group_layout, &texture_view, &sampler);
     let pipeline_layout = create_pipeline_layout(device, &bind_group_layout);
     let render_pipeline = create_render_pipeline(

--- a/nannou/src/draw/renderer/mod.rs
+++ b/nannou/src/draw/renderer/mod.rs
@@ -599,9 +599,7 @@ impl Renderer {
                         None => self.default_texture_view.clone(),
                     };
                     let tex_view_id = tex_view.id();
-                    let texture_component_type = tex_view
-                        .component_type()
-                        .expect("Texture view has no format?");
+                    let texture_component_type = tex_view.component_type();
                     new_tex_views.insert(tex_view_id, tex_view);
 
                     // Determine the new current bind group layout ID, pipeline ID, bind group ID

--- a/nannou/src/frame/mod.rs
+++ b/nannou/src/frame/mod.rs
@@ -301,10 +301,7 @@ impl RenderData {
             device,
             &intermediary_lin_srgba.texture_view,
             src_sample_count,
-            intermediary_lin_srgba
-                .texture_view
-                .component_type()
-                .expect("Texture view has no component type?"),
+            intermediary_lin_srgba.texture_view.component_type(),
             swap_chain_sample_count,
             swap_chain_format,
         );


### PR DESCRIPTION
This adds a `TextureViewInfo` that fulfills the role for `TextureView`
that the `TextureViewDescriptor` used to.

In 0.6, the `TextureViewDescriptor` was changed so that a few of the
fields are optional. This is useful for users of the raw wgpu API, as it
allows for fields that may be trivially inferred from the parent texture
to do just that during the texture view creation process.

Nannou originally stored the `TextureViewDescriptor` in the
`TextureView` type in order to allow the user to access information
about the texture view without having to manually pipe through all the
same information that was used to construct it. The newly introduced
optional fields are inconvenient in this case, as we want to store the
known, built values.

The new `TextureViewInfo` is almost identical to the
`TextureViewDescriptor`, but differs in that all optional arguments that
may be trivially inferred during texture view creation are no longer
optional.