### PR TITLE
Fixes `panic`s in wgpu_compute_shader.rs example

### DIFF
--- a/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
+++ b/examples/wgpu/wgpu_compute_shader/wgpu_compute_shader.rs
@@ -54,7 +54,7 @@ fn model(app: &App) -> Model {
         usage: wgpu::BufferUsage::STORAGE
             | wgpu::BufferUsage::COPY_DST
             | wgpu::BufferUsage::COPY_SRC,
-        mapped_at_creation: true,
+        mapped_at_creation: false,
     });
 
     // Create the buffer that will store time.
@@ -110,10 +110,8 @@ fn update(app: &App, model: &mut Model, _update: Update) {
     let read_buffer = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("read_oscillators"),
         size: compute.oscillator_buffer_size,
-        usage: wgpu::BufferUsage::MAP_READ
-            | wgpu::BufferUsage::COPY_DST
-            | wgpu::BufferUsage::COPY_SRC,
-        mapped_at_creation: true,
+        usage: wgpu::BufferUsage::MAP_READ | wgpu::BufferUsage::COPY_DST,
+        mapped_at_creation: false,
     });
 
     // An update for the uniform buffer with the current time.


### PR DESCRIPTION
Previously the wgpu_compute_shader.rs example would panic in three
places:

1. Due to an unnecessary `COPY_SRC` usage flag on "read-oscillators"
   buffer.
2. Unnecessary `mapped_at_creation` flag on "oscillators" buffer.
2. Unnecessary `mapped_at_creation` flag on "read-oscillators" buffer.

This commit addresses these panics.