### PR TITLE
Make Nannou compile in WASM environment

### DIFF
--- a/nannou/Cargo.toml
+++ b/nannou/Cargo.toml
@@ -22,6 +22,7 @@ daggy = "0.6"
 find_folder = "0.3"
 futures = { version = "0.3", features = ["executor", "thread-pool"] }
 image = "0.23"
+instant = "0.1.9"
 lyon = "0.15"
 noise = "0.6"
 notosans = { version = "0.1", optional = true }

--- a/nannou/src/app.rs
+++ b/nannou/src/app.rs
@@ -18,13 +18,14 @@ use crate::ui;
 use crate::wgpu;
 use crate::window::{self, Window};
 use find_folder;
+use instant::Instant;
 use std;
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{self, AtomicBool};
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use winit;
 use winit::event_loop::ControlFlow;
 
@@ -1276,7 +1277,7 @@ fn run_loop<M, E>(
                 // Trigger some extra updates for conrod GUIs to finish "animating". The number of
                 // updates used to be configurable, but I don't think there's any use besides GUI.
                 if loop_state.updates_since_event < LoopMode::UPDATES_PER_WAIT_EVENT as usize {
-                    let ten_ms = std::time::Instant::now() + std::time::Duration::from_millis(10);
+                    let ten_ms = Instant::now() + std::time::Duration::from_millis(10);
                     ControlFlow::WaitUntil(ten_ms)
                 } else {
                     ControlFlow::Wait

--- a/nannou/src/wgpu/mod.rs
+++ b/nannou/src/wgpu/mod.rs
@@ -54,16 +54,16 @@ pub use self::texture::{
 #[doc(inline)]
 pub use wgpu_upstream::{
     util::{self, BufferInitDescriptor},
-    vertex_attr_array, Adapter, AdapterInfo, AddressMode, Backend, BackendBit, BindGroup,
-    BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
-    BindGroupLayoutEntry, BindingResource, BindingType, BlendDescriptor, BlendFactor,
-    BlendOperation, Buffer, BufferAddress, BufferAsyncError, BufferCopyView, BufferDescriptor,
-    BufferSlice, BufferUsage, BufferView, Color, ColorStateDescriptor, ColorWrite, CommandBuffer,
-    CommandBufferDescriptor, CommandEncoder, CommandEncoderDescriptor, CompareFunction,
-    ComputePass, ComputePipeline, ComputePipelineDescriptor, CullMode, DepthStencilStateDescriptor,
-    Device, DeviceDescriptor, DeviceType, DynamicOffset, Extent3d, Features, FilterMode, FrontFace,
-    IndexFormat, InputStepMode, Instance, Limits, LoadOp, Maintain, MapMode, Operations, Origin3d,
-    PipelineLayout, PipelineLayoutDescriptor, PowerPreference, PresentMode, PrimitiveTopology,
+    vertex_attr_array, Adapter, AddressMode, Backend, BackendBit, BindGroup, BindGroupDescriptor,
+    BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor, BindGroupLayoutEntry,
+    BindingResource, BindingType, BlendDescriptor, BlendFactor, BlendOperation, Buffer,
+    BufferAddress, BufferAsyncError, BufferCopyView, BufferDescriptor, BufferSlice, BufferUsage,
+    BufferView, Color, ColorStateDescriptor, ColorWrite, CommandBuffer, CommandBufferDescriptor,
+    CommandEncoder, CommandEncoderDescriptor, CompareFunction, ComputePass, ComputePipeline,
+    ComputePipelineDescriptor, CullMode, DepthStencilStateDescriptor, Device, DeviceDescriptor,
+    DynamicOffset, Extent3d, Features, FilterMode, FrontFace, IndexFormat, InputStepMode, Instance,
+    Limits, LoadOp, Maintain, MapMode, Operations, Origin3d, PipelineLayout,
+    PipelineLayoutDescriptor, PowerPreference, PresentMode, PrimitiveTopology,
     ProgrammableStageDescriptor, Queue, RasterizationStateDescriptor, RenderPass,
     RenderPassColorAttachmentDescriptor, RenderPassDepthStencilAttachmentDescriptor,
     RenderPassDescriptor, RenderPipeline, RenderPipelineDescriptor, RequestAdapterOptions, Sampler,
@@ -76,6 +76,9 @@ pub use wgpu_upstream::{
     VertexStateDescriptor, BIND_BUFFER_ALIGNMENT, COPY_BUFFER_ALIGNMENT,
     COPY_BYTES_PER_ROW_ALIGNMENT,
 };
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(inline)]
+pub use wgpu_upstream::{AdapterInfo, DeviceType};
 
 pub fn shader_from_spirv_bytes(
     device: &wgpu_upstream::Device,


### PR DESCRIPTION
Awesome work done to upgrade wgpu to the latest version!

This PR will make sure Nannou can be *compiled* with `--target=wasm32-unknown-unknown`. Unfortunately, it crashes when being run in the browser but I will investigate why this is the case.